### PR TITLE
Iam role

### DIFF
--- a/examples/particle/aws/iam/use_iam_role.py/use_iam_role.py
+++ b/examples/particle/aws/iam/use_iam_role.py/use_iam_role.py
@@ -23,7 +23,7 @@ iam_role_example_json = {
     "aws_resource":{
         "custom_config": {
             #optional: leave list empty if no desired policies to attach
-            "policy_arns": ["arn:aws:iam::471916315075:policy/pcf-test2"],
+            "policy_arns": ["arn:aws:iam::12345678910:policy/pcf-test", "arn:aws:iam::12345678910:policy/pcf-test2"],
             #optional
             "IsInstanceProfile": True
         },

--- a/examples/particle/aws/iam/use_iam_role.py/use_iam_role.py
+++ b/examples/particle/aws/iam/use_iam_role.py/use_iam_role.py
@@ -23,7 +23,9 @@ iam_role_example_json = {
     "aws_resource":{
         "custom_config": {
             #optional: leave list empty if no desired policies to attach
-            "policy_arns": ["arn:aws:iam::12345678910:policy/pcf-test", "arn:aws:iam::12345678910:policy/pcf-test2"]
+            "policy_arns": ["arn:aws:iam::471916315075:policy/pcf-test2"],
+            #optional
+            "IsInstanceProfile": True
         },
         "RoleName":"pcf-test", # Required
         "AssumeRolePolicyDocument": json.dumps(assume_role_policy_document), #Required

--- a/examples/particle/aws/iam/use_iam_role.py/use_iam_role_with_policy.py
+++ b/examples/particle/aws/iam/use_iam_role.py/use_iam_role_with_policy.py
@@ -74,6 +74,9 @@ quasiparticle_definition = {
             "flavor": "iam_role",
             "parents":["iam_policy:iam_policy_parent", "iam_policy:iam_policy_parent2"],
             "aws_resource": {
+                "custom_config": {
+                    "IsInstanceProfile": True
+                },
                 "RoleName":"pcf-test", # Required
                 "AssumeRolePolicyDocument": assume_role_policy_document,
             }
@@ -111,6 +114,9 @@ updated_quasiparticle_definition = {
             "flavor": "iam_role",
             "parents":["iam_policy:iam_policy_parent"],
             "aws_resource": {
+               "custom_config": {
+                    "IsInstanceProfile": True
+                },
                 "RoleName":"pcf-test", # Required
                 "AssumeRolePolicyDocument": assume_role_policy_document,
             }

--- a/pcf/particle/aws/iam/iam_role.py
+++ b/pcf/particle/aws/iam/iam_role.py
@@ -130,7 +130,7 @@ class IAMRole(AWSResource):
         create_definition = pcf_util.param_filter(self.get_desired_state_definition(), IAMRole.START_PARAMS_FILTER)
         
         try:
-            role = self.client.create_role(**create_definition)
+            self.client.create_role(**create_definition)
         except ClientError as e:
             raise e
 
@@ -247,10 +247,9 @@ class IAMRole(AWSResource):
 
             if isinstance(self.desired_state_definition.get('AssumeRolePolicyDocument'), str):    
                 self.desired_state_definition['AssumeRolePolicyDocument'] = json.loads(self.desired_state_definition.get('AssumeRolePolicyDocument'))
-
             self.current_state_definition['custom_config']['IsInstanceProfile'] = self.custom_config.get('IsInstanceProfile', False)
-
             diff_dict = pcf_util.diff_dict(self.current_state_definition, self.desired_state_definition)
+
         return diff_dict == {}
 
 

--- a/pcf/particle/aws/iam/iam_role.py
+++ b/pcf/particle/aws/iam/iam_role.py
@@ -19,6 +19,9 @@ from botocore.errorfactory import ClientError
 from pcf.particle.aws.iam.iam_policy import IAMPolicy 
 
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 class IAMRole(AWSResource):
     """
@@ -99,9 +102,22 @@ class IAMRole(AWSResource):
             for policy in attached_policies.get('AttachedPolicies'):
                 self.client.detach_role_policy(RoleName=self.role_name, PolicyArn=policy.get('PolicyArn'))
 
+        if self.custom_config.get('IsInstanceProfile'):
+            try:
+                self.client.remove_role_from_instance_profile(InstanceProfileName=self.role_name, RoleName=self.role_name)
+            except ClientError as e:
+                logger.info(e)
 
+            try:
+                self.client.delete_instance_profile(InstanceProfileName=self.role_name)
+            except ClientError as e:
+                logger.info(e)
 
-        return self.client.delete_role(RoleName=self.role_name)
+        try:
+            self.client.delete_role(RoleName=self.role_name)
+        except ClientError as e:
+            raise e
+
 
     def _start(self):
         """
@@ -114,9 +130,20 @@ class IAMRole(AWSResource):
         create_definition = pcf_util.param_filter(self.get_desired_state_definition(), IAMRole.START_PARAMS_FILTER)
         
         try:
-            self.client.create_role(**create_definition)
+            role = self.client.create_role(**create_definition)
         except ClientError as e:
             raise e
+
+        if self.custom_config.get('IsInstanceProfile', False):
+            try:
+                self.client.create_instance_profile(InstanceProfileName=self.role_name)
+            except ClientError as e:
+                logger.info(e)
+
+            try:
+                self.client.add_role_to_instance_profile(InstanceProfileName=self.role_name, RoleName=self.role_name)
+            except ClientError as e:
+                logger.info(e)
 
     def _stop(self):
         """
@@ -221,8 +248,9 @@ class IAMRole(AWSResource):
             if isinstance(self.desired_state_definition.get('AssumeRolePolicyDocument'), str):    
                 self.desired_state_definition['AssumeRolePolicyDocument'] = json.loads(self.desired_state_definition.get('AssumeRolePolicyDocument'))
 
-            diff_dict = pcf_util.diff_dict(self.current_state_definition, self.desired_state_definition)
+            self.current_state_definition['custom_config']['IsInstanceProfile'] = self.custom_config.get('IsInstanceProfile', False)
 
+            diff_dict = pcf_util.diff_dict(self.current_state_definition, self.desired_state_definition)
         return diff_dict == {}
 
 

--- a/pcf/test/particle/aws/iam/test_iam_role.py
+++ b/pcf/test/particle/aws/iam/test_iam_role.py
@@ -46,7 +46,8 @@ class TestIAMRole:
             "flavor":"iam_role", # Required
             "aws_resource":{
                 "custom_config": {
-                    "policy_arns": []
+                    "policy_arns": [],
+                    "IsInstanceProfile": True
 
                 },
                 "RoleName":"pcf-test", # Required


### PR DESCRIPTION
Adding IsInstanceProfile flag to iam_role's custom_config creates an Instance Profile Role with the same name as Role name (this follows what aws does it when you attach a role to ec2).

Edited test and examples to include IsInstanceProfile flag. 