### PR TITLE
utils - add makefile targets for install and clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ build
 pcf.egg-info
 venv
 !.coveragerc
+bin/
+lib/
+pyvenv.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 .PHONY: docs
 
+clean:
+	rm -rf bin/ lib/
+
+install: clean
+	python3 -m venv .
+	bin/pip install -r requirements.txt
+	bin/pip install -e .
+
 docs:
 	cd docs; make html
 


### PR DESCRIPTION
adds a easy target to install the necessary requirements and pcf itself for those that don't have/use conda-- granted this should also include a target for doing the conda install as well